### PR TITLE
chore: CopierテンプレートとPR品質チェックを更新

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,23 +1,19 @@
-_commit: 996ede6
+_commit: 9428ade
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: みず
 docker_image_name: switchbot-exporter
+docker_login_username: mizucopo
 docker_registry: mizucopo
-project_dependencies:
-- click>=8.1
-- requests>=2.32
-- inflect>=7.4
-- inflection>=0.5
-- flask>=3.0
-- gunicorn>=23.0
-- python-decouple>=3.8
-project_description: Prometheus SwitchBot Exporter
-project_name: switchbot-exporter
-project_version: 2.0.0
 python_version: '3.14'
 use_aws_ecr: false
+use_chrome_extension: false
+use_dependabot_docker: true
+use_dependabot_github_actions: true
+use_docker: true
 use_gh_actions_docker_release: true
 use_gh_actions_pr_tag_check: true
 use_mit_license: true
 use_python: true
+use_rust: false
+use_tauri: false

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
-__pycache__/
-**/__pycache__/
-*.py[cod]
-*$py.class
+# Exclude every build input unless the project explicitly allows it.
+**
+!Dockerfile
+!pyproject.toml
+!uv.lock
+!src/
+!src/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,46 +9,328 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docker-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Read version
         id: version
         run: |
-          echo "version=$(awk -F'\"' '/^version *=/ {print $2}' pyproject.toml)" >> "$GITHUB_OUTPUT"
 
-      - name: Read git author
-        id: author
-        run: |
-          echo "name=$(git log -1 --format=%an)" >> $GITHUB_OUTPUT
-          echo "email=$(git log -1 --format=%ae)" >> $GITHUB_OUTPUT
+          set -euo pipefail
 
-      - name: Configure Git
-        run: |
-          git config user.name "${{ steps.author.outputs.name }}"
-          git config user.email "${{ steps.author.outputs.email }}"
+          fail_version() {
+            printf '%s\n' "$1" > version_check_error.txt
+            echo "::error::$1"
+            exit 1
+          }
 
-      - name: Check if tag exists
+
+          VERSION_RAW="$(awk -F'\"' '/^version *=/ {print $2}' pyproject.toml)"
+
+
+          case "$VERSION_RAW" in
+            *$'\n'*)
+              fail_version "version must contain exactly one line."
+              ;;
+          esac
+
+          VERSION="$(
+            printf '%s' "$VERSION_RAW" \
+              | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+          )"
+
+          if [ -z "$VERSION" ]; then
+            fail_version "version must not be empty."
+          fi
+
+
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            fail_version "version is not a valid Docker release tag."
+          fi
+
+
+          if ! git check-ref-format "refs/tags/$VERSION"; then
+            fail_version "version is not a valid git tag."
+          fi
+
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+
+
+
+      - name: Inspect release state
+        id: release-state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.version }}
         run: |
-          git fetch --tags
-          if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+
+          set -euo pipefail
+
+          git fetch --force --tags
+
+          HEAD_SHA="$(git rev-parse HEAD)"
+          tag_exists=false
+          release_exists=false
+          release_asset_exists=false
+
+          if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
+            TAG_SHA="$(git rev-list -n 1 "refs/tags/$TAG")"
+            if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+              echo "::error::Tag $TAG already points to $TAG_SHA, not $HEAD_SHA."
+              exit 1
+            fi
+            tag_exists=true
+          fi
+
+          RELEASE_RESPONSE="$(mktemp)"
+          trap 'rm -f "$RELEASE_RESPONSE"' EXIT
+
+          set +e
+          RELEASE_HTTP_STATUS="$(
+            curl --silent --show-error --location \
+              --output "$RELEASE_RESPONSE" \
+              --write-out '%{http_code}' \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$TAG"
+          )"
+          CURL_STATUS=$?
+          set -e
+
+          if [ "$CURL_STATUS" -ne 0 ]; then
+            echo "::error::Could not inspect GitHub Release $TAG."
+            exit "$CURL_STATUS"
+          fi
+
+          case "$RELEASE_HTTP_STATUS" in
+            200)
+              release_exists=true
+              ;;
+            404)
+              ;;
+            *)
+              echo "::error::Could not inspect GitHub Release $TAG: HTTP $RELEASE_HTTP_STATUS."
+              exit 1
+              ;;
+          esac
+
+          if [ "$release_exists" = "true" ] && [ "$tag_exists" != "true" ]; then
+            echo "::error::GitHub Release $TAG exists, but the matching git tag was not found."
             exit 1
           fi
 
+          if [ "$release_exists" = "true" ] && [ -n "${RELEASE_ASSET_NAME:-}" ]; then
+            if ! release_asset_exists="$(
+              jq -r --arg name "$RELEASE_ASSET_NAME" \
+                'any(.assets[]?; .name == $name)' \
+                "$RELEASE_RESPONSE"
+            )"; then
+              echo "::error::Could not inspect assets for GitHub Release $TAG."
+              exit 1
+            fi
+            case "$release_asset_exists" in
+              true|false) ;;
+              *)
+                echo "::error::GitHub Release $TAG returned an invalid asset state."
+                exit 1
+                ;;
+            esac
+          fi
+
+          {
+            echo "tag_exists=$tag_exists"
+            echo "release_exists=$release_exists"
+            echo "release_asset_exists=$release_asset_exists"
+          } >> "$GITHUB_OUTPUT"
+
+
+
+      - name: Inspect Docker image state
+        id: image-state
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: "mizucopo"
+          DOCKERHUB_NAMESPACE: "mizucopo"
+          DOCKERHUB_REPOSITORY: "switchbot-exporter"
+          TAG: ${{ steps.version.outputs.version }}
+          TAG_EXISTS: ${{ steps.release-state.outputs.tag_exists }}
+        run: |
+          set -euo pipefail
+          AUTH_RESPONSE="$(mktemp)"
+          trap 'rm -f "$AUTH_RESPONSE"' EXIT
+          AUTH_PAYLOAD="$(
+            jq -cn \
+              --arg identifier "$DOCKERHUB_USERNAME" \
+              --arg secret "$DOCKERHUB_TOKEN" \
+              '{identifier: $identifier, secret: $secret}'
+          )"
+
+          set +e
+          AUTH_HTTP_STATUS="$(
+            curl --silent --show-error --location \
+              --output "$AUTH_RESPONSE" \
+              --write-out '%{http_code}' \
+              --header 'Content-Type: application/json' \
+              --data "$AUTH_PAYLOAD" \
+              https://hub.docker.com/v2/auth/token
+          )"
+          CURL_STATUS=$?
+          set -e
+
+          if [ "$CURL_STATUS" -ne 0 ]; then
+            echo "::error::Could not authenticate with the Docker Hub API."
+            exit "$CURL_STATUS"
+          fi
+          if [ "$AUTH_HTTP_STATUS" != "200" ]; then
+            echo "::error::Could not authenticate with the Docker Hub API: HTTP $AUTH_HTTP_STATUS."
+            exit 1
+          fi
+
+          if ! DOCKERHUB_API_TOKEN="$(
+            jq -er '.access_token | select(type == "string" and length > 0)' \
+              "$AUTH_RESPONSE"
+          )"; then
+            echo "::error::Docker Hub authentication response did not contain an access token."
+            exit 1
+          fi
+          echo "::add-mask::$DOCKERHUB_API_TOKEN"
+
+          read_digest() {
+            local image_tag="$1"
+            local response_file
+            local http_status
+            local curl_status
+            local digest
+            response_file="$(mktemp)"
+
+            set +e
+            http_status="$(
+              curl --silent --show-error --location \
+                --output "$response_file" \
+                --write-out '%{http_code}' \
+                --header "Authorization: Bearer $DOCKERHUB_API_TOKEN" \
+                "https://hub.docker.com/v2/repositories/$DOCKERHUB_NAMESPACE/$DOCKERHUB_REPOSITORY/tags/$image_tag"
+            )"
+            curl_status=$?
+            set -e
+
+            if [ "$curl_status" -ne 0 ]; then
+              rm -f "$response_file"
+              echo "::error::Could not inspect Docker Hub image tag $image_tag." >&2
+              return "$curl_status"
+            fi
+
+            case "$http_status" in
+              200)
+                if ! digest="$(
+                  jq -er \
+                    'def valid_digest:
+                       type == "string" and test("^sha256:[0-9a-f]{64}$");
+                     if has("digest") then
+                       .digest
+                       | select(valid_digest)
+                     elif (.images | type) == "array"
+                       and (.images | length) > 0
+                       and all(.images[].digest; valid_digest)
+                     then
+                       [.images[].digest] | unique | sort | .[]
+                     else
+                       error("Docker Hub tag response did not contain valid image digests")
+                     end' \
+                    "$response_file"
+                )"; then
+                  rm -f "$response_file"
+                  return 1
+                fi
+                rm -f "$response_file"
+                printf '%s\n' "$digest"
+                ;;
+              404)
+                rm -f "$response_file"
+                ;;
+              *)
+                rm -f "$response_file"
+                echo "::error::Could not inspect Docker Hub image tag $image_tag: HTTP $http_status." >&2
+                return 1
+                ;;
+            esac
+          }
+
+          if ! VERSION_DIGEST="$(read_digest "$TAG")"; then
+            echo "::error::Could not resolve a valid digest for image tag $TAG."
+            exit 1
+          fi
+          if ! LATEST_DIGEST="$(read_digest latest)"; then
+            echo "::error::Could not resolve a valid digest for image tag latest."
+            exit 1
+          fi
+
+          version_exists=false
+          latest_exists=false
+          latest_matches=false
+          if [ -n "$VERSION_DIGEST" ]; then
+            version_exists=true
+          fi
+          if [ -n "$LATEST_DIGEST" ]; then
+            latest_exists=true
+          fi
+          if [ "$version_exists" = "true" ] \
+            && [ "$latest_exists" = "true" ] \
+            && [ "$VERSION_DIGEST" = "$LATEST_DIGEST" ]; then
+            latest_matches=true
+          fi
+
+          if [ "$TAG_EXISTS" != "true" ] && [ "$version_exists" = "true" ]; then
+            echo "::error::Image tag $TAG exists without a matching git tag; refusing to associate it with this commit."
+            exit 1
+          fi
+
+          {
+            echo "version_exists=$version_exists"
+            echo "latest_exists=$latest_exists"
+            echo "latest_matches=$latest_matches"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure Git
+        if: steps.release-state.outputs.tag_exists != 'true'
+        env:
+          GIT_USER_NAME: "\u307f\u305a"
+          GIT_USER_EMAIL: "mizu.copo@gmail.com"
+        run: |
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
+
+      - name: Create version tag
+        if: steps.release-state.outputs.tag_exists != 'true'
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+        run: |
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "refs/tags/$TAG"
+
+      - name: Set up Docker Buildx
+        if: steps.image-state.outputs.version_exists != 'true' || steps.image-state.outputs.latest_matches != 'true'
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
+        if: steps.image-state.outputs.version_exists != 'true' || steps.image-state.outputs.latest_matches != 'true'
         uses: docker/login-action@v3
         with:
-          username: mizucopo
+          username: "mizucopo"
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        if: steps.image-state.outputs.version_exists != 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -57,23 +339,31 @@ jobs:
             mizucopo/switchbot-exporter:latest
             mizucopo/switchbot-exporter:${{ steps.version.outputs.version }}
 
-      - name: Create and push git tag
+      - name: Repair latest tag
+        if: steps.image-state.outputs.version_exists == 'true' && steps.image-state.outputs.latest_matches != 'true'
+        env:
+          IMAGE_REPOSITORY: "mizucopo/switchbot-exporter"
+          TAG: ${{ steps.version.outputs.version }}
         run: |
-          git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
-          git push origin "${{ steps.version.outputs.version }}"
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "$IMAGE_REPOSITORY:latest" \
+            "$IMAGE_REPOSITORY:$TAG"
 
       - name: Create GitHub Release
+        if: steps.release-state.outputs.release_exists != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.version }}
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "Release ${{ steps.version.outputs.version }}" \
+          gh release create "$TAG" \
+            --title "Release $TAG" \
             --notes "## Docker Image
 
           Pull the Docker image:
 
           \`\`\`bash
-          docker pull mizucopo/switchbot-exporter:${{ steps.version.outputs.version }}
+          docker pull mizucopo/switchbot-exporter:$TAG
           \`\`\`
 
           Or use the latest tag:
@@ -84,5 +374,5 @@ jobs:
 
           ## Links:
           - [Docker Hub](https://hub.docker.com/r/mizucopo/switchbot-exporter)
-          - [Source Code](${{ github.server_url }}/${{ github.repository }}/tree/${{ steps.version.outputs.version }})
+          - [Source Code](${{ github.server_url }}/${{ github.repository }}/tree/$TAG)
           "

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -34,7 +34,12 @@ jobs:
           SWITCHBOT_API_SECRET: ${{ secrets.SWITCHBOT_API_SECRET }}
           SWITCHBOT_API_TOKEN: ${{ secrets.SWITCHBOT_API_TOKEN }}
         timeout-minutes: 10
-        run: uv run pytest --tb=short -v
+        run: |
+          if [ -n "$SWITCHBOT_API_TOKEN" ] && [ -n "$SWITCHBOT_API_SECRET" ]; then
+            uv run pytest --tb=short -v
+          else
+            uv run pytest --tb=short -v -m "not vcr"
+          fi
 
       - name: Run mypy
         id: mypy

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -2,30 +2,30 @@ name: PR Quality Checks
 
 on:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   quality-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        id: setup-python
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version-file: ".python-version"
 
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run pytest
         id: pytest
@@ -33,59 +33,69 @@ jobs:
         env:
           SWITCHBOT_API_SECRET: ${{ secrets.SWITCHBOT_API_SECRET }}
           SWITCHBOT_API_TOKEN: ${{ secrets.SWITCHBOT_API_TOKEN }}
-        run: |
-          if uv run pytest --tb=short --no-header > pytest_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+        timeout-minutes: 10
+        run: uv run pytest --tb=short -v
 
       - name: Run mypy
         id: mypy
         continue-on-error: true
-        run: |
-          if uv run mypy . > mypy_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+        run: uv run mypy
 
       - name: Run ruff format check
         id: ruff-format
         continue-on-error: true
-        run: |
-          if uv run ruff format --check . > ruff_format_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+        run: uv run ruff format --check .
 
       - name: Run ruff check
         id: ruff-check
         continue-on-error: true
-        run: |
-          if uv run ruff check . > ruff_check_output.txt 2>&1; then
-            RESULT="✅ 成功"
-          else
-            RESULT="❌ 失敗"
-          fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+        run: uv run ruff check .
 
-      - name: Comment on PR
-        if: github.event.pull_request.head.repo.fork == false
+      - name: Build quality check summary
+        id: quality-report
+        if: ${{ !cancelled() }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          PYTEST_OUTCOME: ${{ steps.pytest.outcome }}
+          MYPY_OUTCOME: ${{ steps.mypy.outcome }}
+          RUFF_FORMAT_OUTCOME: ${{ steps.ruff-format.outcome }}
+          RUFF_CHECK_OUTCOME: ${{ steps.ruff-check.outcome }}
         run: |
-          gh pr comment ${{ github.event.number }} --body "
-          ## 🔍 Quality Checks Result
+          format_result() {
+            case "$1" in
+              success) printf '✅ 成功' ;;
+              failure) printf '❌ 失敗' ;;
+              skipped) printf '⏭️ スキップ' ;;
+              *) printf '❓ %s' "${1:-unknown}" ;;
+            esac
+          }
+
+          cat > quality_report.md <<EOF
+          ## Quality Checks Result
 
           | Item | Result |
           |-------------|------|
-          | pytest | ${{ steps.pytest.outputs.result }} |
-          | mypy | ${{ steps.mypy.outputs.result }} |
-          | ruff format | ${{ steps.ruff-format.outputs.result }} |
-          | ruff check | ${{ steps.ruff-check.outputs.result }} |
-          "
+          | pytest | $(format_result "$PYTEST_OUTCOME") |
+          | mypy | $(format_result "$MYPY_OUTCOME") |
+          | ruff format | $(format_result "$RUFF_FORMAT_OUTCOME") |
+          | ruff check | $(format_result "$RUFF_CHECK_OUTCOME") |
+          EOF
+
+          cat quality_report.md >> "$GITHUB_STEP_SUMMARY"
+
+          HAS_FAILURE=false
+          for outcome in \
+            "$PYTEST_OUTCOME" \
+            "$MYPY_OUTCOME" \
+            "$RUFF_FORMAT_OUTCOME" \
+            "$RUFF_CHECK_OUTCOME"; do
+            if [ "$outcome" != "success" ]; then
+              HAS_FAILURE=true
+            fi
+          done
+          echo "has-failure=$HAS_FAILURE" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce quality gate result
+        if: ${{ !cancelled() && steps.quality-report.outputs.has-failure == 'true' }}
+        run: |
+          echo "::error::One or more quality checks failed or were skipped."
+          exit 1

--- a/.github/workflows/pr-tag-check.yml
+++ b/.github/workflows/pr-tag-check.yml
@@ -4,52 +4,390 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
+  checks: write
+
 
 jobs:
   check-tag-conflict:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Read version
         id: version
+        continue-on-error: true
         run: |
-          echo "version=$(awk -F'\"' '/^version *=/ {print $2}' pyproject.toml)" >> "$GITHUB_OUTPUT"
+
+          set -euo pipefail
+
+          fail_version() {
+            printf '%s\n' "$1" > version_check_error.txt
+            echo "::error::$1"
+            exit 1
+          }
+
+
+          VERSION_RAW="$(awk -F'\"' '/^version *=/ {print $2}' pyproject.toml)"
+
+
+          case "$VERSION_RAW" in
+            *$'\n'*)
+              fail_version "version must contain exactly one line."
+              ;;
+          esac
+
+          VERSION="$(
+            printf '%s' "$VERSION_RAW" \
+              | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+          )"
+
+          if [ -z "$VERSION" ]; then
+            fail_version "version must not be empty."
+          fi
+
+
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            fail_version "version is not a valid Docker release tag."
+          fi
+
+
+          if ! git check-ref-format "refs/tags/$VERSION"; then
+            fail_version "version is not a valid git tag."
+          fi
+
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+
+
 
       - name: Check if tag exists
         id: tag
+        if: steps.version.outcome == 'success'
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+
           git fetch --tags
-          if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+          if git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment on PR
+      - name: Check if GitHub Release exists
+        id: release
+        if: steps.version.outcome == 'success'
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if [ "${{ steps.tag.outputs.exists }}" = "true" ]; then
-            MESSAGE="$(printf '%s\n' \
-              "## Version Tag Check ❌" \
-              "" \
-              "The version \`${{ steps.version.outputs.version }}\` already exists as a git tag." \
-              "" \
-              "Please update the version with a new version number before merging.")"
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$MESSAGE"
-            exit 1
-          else
-            MESSAGE="$(printf '%s\n' \
-              "## Version Tag Check ✅" \
-              "" \
-              "The version \`${{ steps.version.outputs.version }}\` does not exist as a git tag." \
-              "" \
-              "This version is available for use.")"
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$MESSAGE"
+          set -euo pipefail
+
+          set +e
+          RELEASE_HTTP_STATUS="$(
+            curl --silent --show-error --location \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"
+          )"
+          CURL_STATUS=$?
+          set -e
+
+          if [ "$CURL_STATUS" -ne 0 ]; then
+            echo "::error::Could not inspect GitHub Release $VERSION."
+            exit "$CURL_STATUS"
           fi
+
+          case "$RELEASE_HTTP_STATUS" in
+            200)
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Could not inspect GitHub Release $VERSION: HTTP $RELEASE_HTTP_STATUS."
+              exit 1
+              ;;
+          esac
+
+
+
+      - name: Check Docker Hub image tag
+        id: image
+        if: steps.version.outcome == 'success'
+        continue-on-error: true
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: "mizucopo"
+          DOCKERHUB_NAMESPACE: "mizucopo"
+          DOCKERHUB_REPOSITORY: "switchbot-exporter"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          AUTH_RESPONSE="$(mktemp)"
+          trap 'rm -f "$AUTH_RESPONSE"' EXIT
+          AUTH_PAYLOAD="$(
+            jq -cn \
+              --arg identifier "$DOCKERHUB_USERNAME" \
+              --arg secret "$DOCKERHUB_TOKEN" \
+              '{identifier: $identifier, secret: $secret}'
+          )"
+
+          set +e
+          AUTH_HTTP_STATUS="$(
+            curl --silent --show-error --location \
+              --output "$AUTH_RESPONSE" \
+              --write-out '%{http_code}' \
+              --header 'Content-Type: application/json' \
+              --data "$AUTH_PAYLOAD" \
+              https://hub.docker.com/v2/auth/token
+          )"
+          CURL_STATUS=$?
+          set -e
+
+          if [ "$CURL_STATUS" -ne 0 ]; then
+            echo "::error::Could not authenticate with the Docker Hub API."
+            exit "$CURL_STATUS"
+          fi
+          if [ "$AUTH_HTTP_STATUS" != "200" ]; then
+            echo "::error::Could not authenticate with the Docker Hub API: HTTP $AUTH_HTTP_STATUS."
+            exit 1
+          fi
+
+          if ! DOCKERHUB_API_TOKEN="$(
+            jq -er '.access_token | select(type == "string" and length > 0)' \
+              "$AUTH_RESPONSE"
+          )"; then
+            echo "::error::Docker Hub authentication response did not contain an access token."
+            exit 1
+          fi
+          echo "::add-mask::$DOCKERHUB_API_TOKEN"
+
+          set +e
+          IMAGE_HTTP_STATUS="$(
+            curl --silent --show-error --location \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --header "Authorization: Bearer $DOCKERHUB_API_TOKEN" \
+              "https://hub.docker.com/v2/namespaces/$DOCKERHUB_NAMESPACE/repositories/$DOCKERHUB_REPOSITORY/tags/$VERSION"
+          )"
+          CURL_STATUS=$?
+          set -e
+
+          if [ "$CURL_STATUS" -ne 0 ]; then
+            echo "::error::Could not inspect Docker Hub image tag $DOCKERHUB_NAMESPACE/$DOCKERHUB_REPOSITORY:$VERSION."
+            exit "$CURL_STATUS"
+          fi
+
+          case "$IMAGE_HTTP_STATUS" in
+            200)
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Could not inspect Docker Hub image tag $DOCKERHUB_NAMESPACE/$DOCKERHUB_REPOSITORY:$VERSION: HTTP $IMAGE_HTTP_STATUS."
+              exit 1
+              ;;
+          esac
+
+
+
+      - name: Build release version availability summary
+        id: tag-report
+        if: always()
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          VERSION_OUTCOME: ${{ steps.version.outcome }}
+          TAG_OUTCOME: ${{ steps.tag.outcome }}
+          TAG_EXISTS: ${{ steps.tag.outputs.exists }}
+          RELEASE_OUTCOME: ${{ steps.release.outcome }}
+          RELEASE_EXISTS: ${{ steps.release.outputs.exists }}
+
+          IMAGE_OUTCOME: ${{ steps.image.outcome }}
+          IMAGE_EXISTS: ${{ steps.image.outputs.exists }}
+
+          IMAGE_REPOSITORY: "mizucopo/switchbot-exporter"
+
+
+        run: |
+          set -euo pipefail
+
+          AVAILABILITY_CHECK_COMPLETED="true"
+          AVAILABILITY_CONFLICT="false"
+          VERSION_SOURCE_VALIDATION_FAILED="false"
+          DETAILS="$(mktemp)"
+          trap 'rm -f "$DETAILS"' EXIT
+
+          IMAGE_REFERENCE="$IMAGE_REPOSITORY:$VERSION"
+
+
+          if [ "$VERSION_OUTCOME" != "success" ]; then
+            AVAILABILITY_CHECK_COMPLETED="false"
+
+            VERSION_ERROR="The version could not be read, so release version availability was not checked."
+            if [ -s version_check_error.txt ]; then
+              VERSION_ERROR="$(< version_check_error.txt)"
+            fi
+            printf '%s\n' "$VERSION_ERROR" >> "$DETAILS"
+          else
+            case "$TAG_OUTCOME:$TAG_EXISTS" in
+              success:true)
+                AVAILABILITY_CONFLICT="true"
+                printf '%s\n' "- The version \`$VERSION\` already exists as a git tag." >> "$DETAILS"
+                ;;
+              success:false)
+                printf '%s\n' "- Git tag \`$VERSION\` is available." >> "$DETAILS"
+                ;;
+              *)
+                AVAILABILITY_CHECK_COMPLETED="false"
+                printf '%s\n' "- The version \`$VERSION\` could not be checked against git tags." >> "$DETAILS"
+                ;;
+            esac
+
+            case "$RELEASE_OUTCOME:$RELEASE_EXISTS" in
+              success:true)
+                AVAILABILITY_CONFLICT="true"
+                printf '%s\n' "- The version \`$VERSION\` already exists as a GitHub Release." >> "$DETAILS"
+                ;;
+              success:false)
+                printf '%s\n' "- GitHub Release \`$VERSION\` is available." >> "$DETAILS"
+                ;;
+              *)
+                AVAILABILITY_CHECK_COMPLETED="false"
+                printf '%s\n' "- The version \`$VERSION\` could not be checked against GitHub Releases." >> "$DETAILS"
+                ;;
+            esac
+
+
+              case "$IMAGE_OUTCOME:$IMAGE_EXISTS" in
+                success:true)
+                  AVAILABILITY_CONFLICT="true"
+
+                  printf '%s\n' "- The image \`$IMAGE_REFERENCE\` already exists as a Docker Hub image tag." >> "$DETAILS"
+
+                  ;;
+                success:false)
+
+                  printf '%s\n' "- Docker Hub image tag \`$IMAGE_REFERENCE\` is available." >> "$DETAILS"
+
+                  ;;
+                *)
+                  AVAILABILITY_CHECK_COMPLETED="false"
+
+                  printf '%s\n' "- Docker Hub image tag \`$IMAGE_REFERENCE\` could not be checked." >> "$DETAILS"
+
+                  ;;
+              esac
+
+
+          fi
+
+          if [ "$AVAILABILITY_CHECK_COMPLETED" = "true" ] \
+            && [ "$AVAILABILITY_CONFLICT" = "false" ]; then
+            {
+              cat <<'EOF'
+          ## Release Version Availability ✅
+
+          EOF
+              cat "$DETAILS"
+              cat <<'EOF'
+
+          This version is available for use.
+          EOF
+            } > tag_report.md
+          else
+            {
+              cat <<'EOF'
+          ## Release Version Availability ❌
+
+          EOF
+              cat "$DETAILS"
+              if [ "$AVAILABILITY_CONFLICT" = "true" ]; then
+                cat <<'EOF'
+
+          Please update the version with a new version number before merging.
+          EOF
+              elif [ "$AVAILABILITY_CHECK_COMPLETED" != "true" ]; then
+                cat <<'EOF'
+
+          Release version availability could not be confirmed.
+          EOF
+              fi
+            } > tag_report.md
+          fi
+
+          cat tag_report.md >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "summary<<EOF"
+            cat tag_report.md
+            echo "EOF"
+            echo "availability_check_completed=$AVAILABILITY_CHECK_COMPLETED"
+            echo "availability_conflict=$AVAILABILITY_CONFLICT"
+            echo "version_source_validation_failed=$VERSION_SOURCE_VALIDATION_FAILED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish version tag check
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        uses: actions/github-script@v9
+        continue-on-error: true
+        env:
+          SUMMARY: ${{ steps.tag-report.outputs.summary }}
+          AVAILABILITY_CHECK_COMPLETED: ${{ steps.tag-report.outputs.availability_check_completed }}
+          AVAILABILITY_CONFLICT: ${{ steps.tag-report.outputs.availability_conflict }}
+          VERSION_SOURCE_VALIDATION_FAILED: ${{ steps.tag-report.outputs.version_source_validation_failed }}
+        with:
+          script: |
+            const availabilityCheckCompleted =
+              process.env.AVAILABILITY_CHECK_COMPLETED === "true";
+            const availabilityConflict =
+              process.env.AVAILABILITY_CONFLICT === "true";
+            const versionSourceValidationFailed =
+              process.env.VERSION_SOURCE_VALIDATION_FAILED === "true";
+
+            let checkConclusion = "failure";
+            let checkTitle = "Release version availability check could not complete";
+            if (versionSourceValidationFailed) {
+              checkTitle = "Chrome extension version source validation failed";
+            } else if (availabilityCheckCompleted && !availabilityConflict) {
+              checkConclusion = "success";
+              checkTitle = "Release version is available";
+            } else if (availabilityCheckCompleted && availabilityConflict) {
+              checkTitle = "Release version is already in use";
+            }
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Version Tag Check",
+              head_sha: context.payload.pull_request.head.sha,
+              status: "completed",
+              conclusion: checkConclusion,
+              output: {
+                title: checkTitle,
+                summary: process.env.SUMMARY,
+              },
+            });
+
+      - name: Enforce version tag availability
+        if: >-
+          always() &&
+          (steps.tag-report.outputs.availability_check_completed != 'true' ||
+          steps.tag-report.outputs.availability_conflict != 'false')
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,132 +1,53 @@
-# Created by https://www.toptal.com/developers/gitignore/api/pythonvanilla,macos,linux
-# Edit at https://www.toptal.com/developers/gitignore?templates=pythonvanilla,macos,linux
-
-### Linux ###
-*~
-
-# temporary files which can be created if a process still has a handle open of a deleted file
-.fuse_hidden*
-
-# KDE directory preferences
-.directory
-
-# Linux trash folder which might appear on any partition or disk
-.Trash-*
-
-# .nfs files are created when an open file is removed but is still being accessed
-.nfs*
-
-### macOS ###
-# General
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-### macOS Patch ###
-# iCloud generated files
-*.icloud
-
-### PythonVanilla ###
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
+*.pyc
+*.pyo
+*.pyd
 .Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
 MANIFEST
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-### uv virtual environments ###
+# Virtual Environment
 .venv/
-.venv
+venv/
+ENV/
+env/
 
-
-# End of https://www.toptal.com/developers/gitignore/api/pythonvanilla,macos,linux
-
-
-# Original Additions
-.secrets
+# Environment/Secrets Variables
 .env
+.secrets
 
-# VCR cassettes
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
 tests/cassettes/
+
+# Distribution
+build/
+dist/
+
+# Rust
+target/
+src-tauri/gen/schemas/
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Coverage
+coverage/
+
+# macOS
+.DS_Store
+
+# VS Code
+*.code-workspace
+
+# Superpowers docs
+docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+## Issue-First Branch Workflow
+
+### WHAT
+
+- Never make changes directly on `main`.
+- Before starting work, create a GitHub Issue that describes the work.
+- Perform the work on a non-`main` branch associated with that Issue.
+
+## Documentation
+
+### HOW
+
+- Update related documentation when code changes affect users
+- Document usage for new features in README
+- Update relevant docs when interfaces change
+- Split large docs into separate files in `docs/` folder
+- Add links to split docs in README
+
+## File Operations
+
+### HOW
+
+```bash
+# File operations
+git mv <old-path> <new-path>  # Move files
+git rm <path>                  # Delete files
+```
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The default five-role vocabulary is used. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repository uses a single-context layout. See `docs/agents/domain.md`.
+
+## Code Organization Rules
+
+### WHY
+
+Maintain consistent structure to ensure readability, maintainability, and testability.
+Follow single responsibility principle to minimize scope of changes.
+
+### WHAT
+
+- One class per file
+- One test file per class
+- Keep `__init__.py` files empty
+- Never modify pyproject.toml when fixing linting errors
+
+### HOW
+
+- Create a new file when adding a new class
+- Name test files as `test_<filename>.py`
+- Fix lint errors in code, never relax configuration
+- Place imports at the top of the file, never in the middle
+
+## Testing Guidelines
+
+### WHAT
+
+- **Framework**: Use function-based tests (pytest), not class-based
+- **Language**: Write test comments (especially AAA steps) and docstrings in Japanese to clarify intent
+- **Strategy**: Test "What" (observable behavior/results), not "How" (implementation details)
+- **Mocking**: Minimize mocks. Use real instances for domain logic; mock only external boundaries (DB, API, SMTP)
+- **Architecture**: Separate domain logic from IO. Use Humble Object/Hexagonal patterns for testability
+- **Scope**: Never test private methods directly. Cover them indirectly via public interfaces
+
+### HOW
+
+- Structure with **AAA Pattern** (Arrange, Act, Assert) with explicit sections in both docstrings and code comments, written in Japanese
+  - **Docstring**: Include `Arrange:`, `Act:`, `Assert:` lines describing each step
+  - **Code comments**: Insert `# Arrange`, `# Act`, `# Assert` as section dividers in the test function body
+- **Naming**: Use English for test function names, describing business requirements
+- **File placement**: Mirror source module structure in `tests/` directory
+- **Docstring**: Describe a summary of what is being tested (in Japanese)
+- **Docstring style**: Use passive voice ("〜こと" form) consistently
+  - Title: "〜を検証" → "〜されること", "〜が〜されること"
+  - When: "〜を選択", "〜を実行" → "〜が選択され", "〜が実行される"
+  - Then: "〜を返す", "〜が生成" → "〜が返されること", "〜が生成されること"
+
+## Quality Check
+
+### HOW
+
+```bash
+uv run task test
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+## Issue-First Branch Workflow
+
+### WHAT
+
+- Never make changes directly on `main`.
+- Before starting work, create a GitHub Issue that describes the work.
+- Perform the work on a non-`main` branch associated with that Issue.
+
+## Documentation
+
+### HOW
+
+- Update related documentation when code changes affect users
+- Document usage for new features in README
+- Update relevant docs when interfaces change
+- Split large docs into separate files in `docs/` folder
+- Add links to split docs in README
+
+## File Operations
+
+### HOW
+
+```bash
+# File operations
+git mv <old-path> <new-path>  # Move files
+git rm <path>                  # Delete files
+```
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The default five-role vocabulary is used. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repository uses a single-context layout. See `docs/agents/domain.md`.
+
+## Code Organization Rules
+
+### WHY
+
+Maintain consistent structure to ensure readability, maintainability, and testability.
+Follow single responsibility principle to minimize scope of changes.
+
+### WHAT
+
+- One class per file
+- One test file per class
+- Keep `__init__.py` files empty
+- Never modify pyproject.toml when fixing linting errors
+
+### HOW
+
+- Create a new file when adding a new class
+- Name test files as `test_<filename>.py`
+- Fix lint errors in code, never relax configuration
+- Place imports at the top of the file, never in the middle
+
+## Testing Guidelines
+
+### WHAT
+
+- **Framework**: Use function-based tests (pytest), not class-based
+- **Language**: Write test comments (especially AAA steps) and docstrings in Japanese to clarify intent
+- **Strategy**: Test "What" (observable behavior/results), not "How" (implementation details)
+- **Mocking**: Minimize mocks. Use real instances for domain logic; mock only external boundaries (DB, API, SMTP)
+- **Architecture**: Separate domain logic from IO. Use Humble Object/Hexagonal patterns for testability
+- **Scope**: Never test private methods directly. Cover them indirectly via public interfaces
+
+### HOW
+
+- Structure with **AAA Pattern** (Arrange, Act, Assert) with explicit sections in both docstrings and code comments, written in Japanese
+  - **Docstring**: Include `Arrange:`, `Act:`, `Assert:` lines describing each step
+  - **Code comments**: Insert `# Arrange`, `# Act`, `# Assert` as section dividers in the test function body
+- **Naming**: Use English for test function names, describing business requirements
+- **File placement**: Mirror source module structure in `tests/` directory
+- **Docstring**: Describe a summary of what is being tested (in Japanese)
+- **Docstring style**: Use passive voice ("〜こと" form) consistently
+  - Title: "〜を検証" → "〜されること", "〜が〜されること"
+  - When: "〜を選択", "〜を実行" → "〜が選択され", "〜が実行される"
+  - Then: "〜を返す", "〜が生成" → "〜が返されること", "〜が生成されること"
+
+## Quality Check
+
+### HOW
+
+```bash
+uv run task test
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY src ./
 
 RUN apk add --no-cache gcc python3-dev musl-dev linux-headers \
   && pip install --no-cache-dir uv \
-  && uv sync --frozen \
+  && uv sync --frozen --no-install-project \
   && rm -rf /root/.cache/uv
 
 CMD [".venv/bin/gunicorn", "-w", "4", "-b", "0.0.0.0:9171", "--timeout", "180", "--chdir", "/app", "app:app"]

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,24 @@
+# Domain docs
+
+This repository uses a single-context domain documentation layout.
+
+## Before exploring
+
+Read the following sources when they exist and are relevant to the work:
+
+- `CONTEXT.md` at the repository root
+- ADRs under `docs/adr/`
+
+Proceed silently when either source does not exist. Domain-modeling workflows
+create them lazily when terminology or architectural decisions need to be
+recorded.
+
+## Vocabulary and decisions
+
+- Use terminology defined in `CONTEXT.md` in issue titles, implementation plans,
+  test names, and other engineering output.
+- Surface any conflict with an existing ADR explicitly instead of silently
+  overriding the decision.
+
+Repositories with multiple bounded contexts should replace this document with
+their context map and context-specific documentation paths.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,23 @@
+# Issue tracker: GitHub Issues
+
+Issues for this repository are tracked in GitHub Issues. Infer the repository
+from the configured Git remote instead of hard-coding an owner or repository
+name in agent instructions.
+
+## Conventions
+
+- Create implementation issues and review-follow-up issues as GitHub Issues.
+- Read the full issue body, comments, and labels before acting on an issue.
+- Include enough context for an agent to act: source URL, affected files or
+  lines when available, problem statement, and expected resolution or open
+  question.
+- Use GitHub's native issue dependencies for blocking relationships when they
+  are available. Otherwise, record blockers in the issue body.
+- Treat pull requests as implementation and review surfaces, not as substitutes
+  for triage issues.
+
+## Skill terminology
+
+When a skill says to publish a ticket, create a GitHub Issue. When a skill says
+to fetch a ticket, read the corresponding GitHub Issue. Prefer an available
+GitHub integration and use the `gh` CLI as the fallback.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,16 @@
+# Triage labels
+
+The engineering skills use five canonical triage roles. The same strings are
+used as GitHub labels by default.
+
+| Canonical role    | GitHub label      | Meaning                                           |
+| ----------------- | ----------------- | ------------------------------------------------- |
+| `needs-triage`    | `needs-triage`    | Maintainer review and classification are required |
+| `needs-info`      | `needs-info`      | More information is required from the reporter    |
+| `ready-for-agent` | `ready-for-agent` | An agent can implement the fully specified issue  |
+| `ready-for-human` | `ready-for-human` | Human judgment or implementation is required      |
+| `wontfix`         | `wontfix`         | The issue will not be actioned                    |
+
+When a skill refers to a canonical triage role, apply the corresponding GitHub
+label from this table. Repositories that use different labels should update the
+mapping while preserving the canonical roles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switchbot-exporter"
-version = "2.0.0"
+version = "2.0.1"
 description = "Prometheus SwitchBot Exporter"
 authors = [
     {name = "みず", email = "mizu.copo@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "taskipy>=1.14.1",
     "types-requests>=2.32.4.20250913",
     "vcrpy>=8.1.0",
+    "vulture>=2.14",
 ]
 
 [tool.pytest.ini_options]
@@ -39,11 +40,16 @@ line-length = 88
 target-version = "py314"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "ARG", "D"]
+select = [
+    "E", "W", "F",   # 基本
+    "I",             # import
+    "B",             # bugbear
+    "SIM",           # simplify
+    "C4",            # comprehension
+    "ARG",           # unused args
+]
 
 [tool.ruff.lint.per-file-ignores]
-"src/cloud_storage_provider.py" = ["ARG002"]
-"src/backup_provider.py" = ["ARG002"]
 "tests/**/*.py" = ["D"]
 
 [tool.ruff.lint.pydocstyle]
@@ -52,8 +58,11 @@ convention = "google"
 [tool.mypy]
 strict = true
 python_version = "3.14"
-files = ["src", "tests", "stubs"]
+files = ["src", "tests"]
 mypy_path = "src:stubs"
 
 [tool.taskipy.tasks]
 test = "ruff check --fix src tests stubs && ruff format src tests stubs && mypy && pytest"
+
+[tool.uv]
+package = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 from decouple import AutoConfig
 
-
 # python-decoupleを使用して.envファイルを読み込む
 # プロジェクトルートを検索パスとして設定
 search_path = Path(__file__).parent.parent

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,9 +2,10 @@ import os
 import unittest
 from unittest.mock import patch
 
+from decouple import UndefinedValueError
+
 from app import generate_prometheus_response_text
 from config import get_optional_env_var, get_required_env_var
-from decouple import UndefinedValueError
 from switchbot import SwitchbotMetrics
 
 
@@ -40,6 +41,7 @@ class TestApp(unittest.TestCase):
         """環境変数から設定が正しく読み込まれることを確認."""
         # モジュールを再インポートして環境変数を反映
         import importlib
+
         import app
 
         importlib.reload(app)
@@ -53,9 +55,11 @@ class TestApp(unittest.TestCase):
 
     def test_required_env_var_missing(self) -> None:
         """必須環境変数が未設定の場合に例外が発生することを確認."""
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(UndefinedValueError):
-                get_required_env_var("MISSING_VAR")
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            self.assertRaises(UndefinedValueError),
+        ):
+            get_required_env_var("MISSING_VAR")
 
     def test_optional_env_var_defaults(self) -> None:
         """任意環境変数が未設定の場合にデフォルト値が使用されることを確認."""

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,10 @@
+"""Docker image build contract tests."""
+
+from pathlib import Path
+
+
+def test_docker_build_installs_dependencies_without_installing_project() -> None:
+    """Flattened application modules are not installed as a Python package."""
+    dockerfile = Path("Dockerfile").read_text()
+
+    assert "uv sync --frozen --no-install-project" in dockerfile

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,10 +1,20 @@
-"""Docker image build contract tests."""
+"""Docker image build契約のテスト。"""
 
 from pathlib import Path
 
 
 def test_docker_build_installs_dependencies_without_installing_project() -> None:
-    """Flattened application modules are not installed as a Python package."""
-    dockerfile = Path("Dockerfile").read_text()
+    """flat配置のapplication moduleがPython packageとしてinstallされないこと。
 
+    Arrange: Dockerfileのpathが用意される。
+    Act: Dockerfileの内容が読み込まれる。
+    Assert: root projectをinstallしないuv sync commandが指定されること。
+    """
+    # Arrange
+    dockerfile_path = Path("Dockerfile")
+
+    # Act
+    dockerfile = dockerfile_path.read_text()
+
+    # Assert
     assert "uv sync --frozen --no-install-project" in dockerfile

--- a/tests/test_pr_quality_checks_workflow.py
+++ b/tests/test_pr_quality_checks_workflow.py
@@ -1,0 +1,74 @@
+"""PR quality checks workflowの回帰テスト。"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WORKFLOW_PATH = Path(".github/workflows/pr-quality-checks.yml")
+
+
+def load_pytest_script() -> str:
+    """Run pytest stepのshell scriptを読み込む。"""
+    workflow = WORKFLOW_PATH.read_text()
+    step = workflow.split("      - name: Run pytest\n", 1)[1].split(
+        "\n      - name: Run mypy", 1
+    )[0]
+    run_section = step.split("        run:", 1)[1]
+    first_line, *remaining_lines = run_section.splitlines()
+
+    if first_line.strip() != "|":
+        return first_line.strip()
+
+    script_lines = [
+        line.removeprefix("          ")
+        for line in remaining_lines
+        if not line or line.startswith("          ")
+    ]
+    return "\n".join(script_lines)
+
+
+@pytest.mark.parametrize(
+    ("api_token", "api_secret", "expected_arguments"),
+    [
+        ("", "", ["run", "pytest", "--tb=short", "-v", "-m", "not vcr"]),
+        ("token", "secret", ["run", "pytest", "--tb=short", "-v"]),
+    ],
+)
+def test_pytest_command_depends_on_switchbot_credentials(
+    tmp_path: Path,
+    api_token: str,
+    api_secret: str,
+    expected_arguments: list[str],
+) -> None:
+    """認証情報の有無に応じたpytest対象が選択されること。
+
+    Arrange: pytest stepと引数を記録するfake uvが用意される。
+    Act: SwitchBot認証情報を指定してpytest stepが実行される。
+    Assert: secretなしではVCRテストが除外され、secretありでは全件実行される。
+    """
+    # Arrange
+    arguments_path = tmp_path / "uv-arguments.txt"
+    fake_uv_path = tmp_path / "uv"
+    fake_uv_path.write_text('#!/bin/sh\nprintf \'%s\\n\' "$@" > "$UV_ARGS_FILE"\n')
+    fake_uv_path.chmod(0o755)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{tmp_path}:{environment['PATH']}",
+            "SWITCHBOT_API_TOKEN": api_token,
+            "SWITCHBOT_API_SECRET": api_secret,
+            "UV_ARGS_FILE": str(arguments_path),
+        }
+    )
+
+    # Act
+    subprocess.run(
+        ["bash", "-c", load_pytest_script()],
+        check=True,
+        env=environment,
+    )
+
+    # Assert
+    assert arguments_path.read_text().splitlines() == expected_arguments

--- a/uv.lock
+++ b/uv.lock
@@ -447,7 +447,7 @@ wheels = [
 [[package]]
 name = "switchbot-exporter"
 version = "2.0.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "flask" },
@@ -469,6 +469,7 @@ dev = [
     { name = "taskipy" },
     { name = "types-requests" },
     { name = "vcrpy" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -493,6 +494,7 @@ dev = [
     { name = "taskipy", specifier = ">=1.14.1" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
     { name = "vcrpy", specifier = ">=8.1.0" },
+    { name = "vulture", specifier = ">=2.14" },
 ]
 
 [[package]]
@@ -588,6 +590,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/23/74/4200cb68d59e86849992eb6512d969cd561051f034e017428e040b113974/vcrpy-8.1.0.tar.gz", hash = "sha256:e585ca3cd9bb751e402728a00394847561250588eebc047b4d3c8948d5487733", size = 85930, upload-time = "2025-12-08T16:46:13.049Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/77/892bcd82445ac949816205b51ab80deb86a492a315f2e290ed4eab35021c/vcrpy-8.1.0-py3-none-any.whl", hash = "sha256:fc4fb6e954c6d082ba6d329c6f3d1228f5b1b1d2836f9022c301b587cfad7378", size = 42748, upload-time = "2025-12-08T16:46:12.08Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ wheels = [
 
 [[package]]
 name = "switchbot-exporter"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 概要

- mizucopo/repo-templateを996ede6から9428adeへ更新
- Docker release、PR quality、version availability workflowをテンプレート標準へ同期
- Dependabot設定とagent向け文書を追加
- Docker利用などのCopier回答を現行構成に合わせて更新
- project versionを2.0.1へ更新
- SwitchBot secretを利用できないfork／Dependabot PRでは非VCRテストのみ実行
- Docker imageではroot projectをinstallせず、依存関係のみ同期

## リポジトリ固有差分

- Docker build contextへpyproject.toml、uv.lock、srcを許可
- Dockerのflat module配置ではuv sync --no-install-projectを使用
- secretありではSwitchBot APIテストを含む全pytestを実行
- secretなしではpytest -m "not vcr"を実行し、APIを呼ぶVCRテストだけ除外
- VCR cassette除外と既存project metadata・依存関係を維持
- フラットmodule構成と競合するsrc/__init__.pyは生成対象から除外

## 意図したテンプレート契約

- PRのDocker Hub tag確認は、認証情報を利用できないfork／Dependabot PRを含め、確認不能時にfail-closedとする（mizucopo/repo-template#39、PR #49）
- Docker releaseはgit tagでcommitとversionを先に予約し、同一commitの部分失敗のみstate inspectionから再開する
- release修正に新しいcommitが必要な場合は既存tagを移動せず、次のSemVerを使用する

## 検証

- copier-update-preview
- 最新テンプレートの再render比較
- actionlint
- uv lock --check（version更新前後とreview修正後）
- Ruff: 成功
- Ruff format: 成功
- mypy: 成功
- workflow分岐の回帰テスト: 2件成功
- Dockerfile契約テスト: 1件成功
- secretなしpytest: 14件成功、VCR 3件のみ除外
- READMEなし・srcを直下展開したDocker同等配置でuv sync --frozen --no-install-project: 成功
- Docker image build: ローカルDocker daemon停止中のため未実施
- git diff --check

## Follow-up

Refs mizucopo/repo-template#52
Refs mizucopo/repo-template#54
